### PR TITLE
fix: make s a tensor in logdet_abs

### DIFF
--- a/dagrad/hfunction/h_functions.py
+++ b/dagrad/hfunction/h_functions.py
@@ -140,7 +140,9 @@ class h_fn:
             return h, G_h
         elif isinstance(W, torch.Tensor):
             device = W.device
-            I = torch.eye(d, device=device)
+            dtype = W.dtype
+            I = torch.eye(d, device=device, dtype=dtype)
+            s = torch.tensor(s, device=device, dtype=dtype)
             M = s* I - torch.abs(W)
             h = - torch.slogdet(M)[1] + d * torch.log(s)
             return h


### PR DESCRIPTION
Currently, if you run dagrad using compute lib torch and h_fn h_logdet_abs, it exits with: "TypeError: log(): argument 'input' (position 1) must be Tensor, not float"